### PR TITLE
Use -ListAvailable for Get-Module PSReadline bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,7 +15,7 @@ Environment data
 ```powershell
 & {
     "PS version: $($PSVersionTable.PSVersion)"
-    $v = (Get-Module PSReadline).Version
+    $v = (Get-Module PSReadline -ListAvailable).Version
     $m = Get-Content "$(Split-Path -Parent (Get-Module PSReadLine).Path)\PSReadLine.psd1" | Select-String "Prerelease = '(.*)'"
     if ($m) {
         $v = "$v-" + $m.Matches[0].Groups[1].Value


### PR DESCRIPTION
My VM is a bit weird where some modules do not auto-load in some PowerShell instances (at least the first time before they are being used by a different host such as e.g. the ISE). Therefore the issue template did not work for me.